### PR TITLE
Improve the error handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  silent: true, // Mutes the `console.*` calls
 }

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -37,6 +37,7 @@ function parseInput() {
 }
 
 function printResponse(response: CloudFrontResultResponse, fullBody: boolean) {
+  console.log('Response:')
   console.log('')
   console.log(`HTTP/2 ${response.status} ${response.statusDescription ?? 'OK'}`)
   for (const [name, values] of Object.entries(response.headers || {})) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,20 +51,15 @@ async function handleInexactProjectVersion({
   version,
   route,
 }: UriDataInexactVersion): Promise<CloudFrontResultResponse> {
-  let exactVersion: string
+  const exactVersion = await getPackageGreatestVersion(
+    version.npmPackage,
+    intersectVersionRanges(version.versionRange, version.requestedRange),
+    version.excludeVersions,
+    true,
+  )
 
-  try {
-    exactVersion = await getPackageGreatestVersion(
-      version.npmPackage,
-      intersectVersionRanges(version.versionRange, version.requestedRange),
-      version.excludeVersions,
-      true,
-    )
-  } catch (error) {
-    if (isNpmNotFoundError(error)) {
-      return makeNotFoundResponse(`There is no version matching ${version.requestedRange.start}.*`, false)
-    }
-    throw error
+  if (exactVersion === undefined) {
+    return makeNotFoundResponse(`There is no version matching ${version.requestedRange.start}.*`, false)
   }
 
   // If the route is a redirect, follow that redirect to make browser do 1 redirect instead of 2

--- a/src/npm.test.ts
+++ b/src/npm.test.ts
@@ -38,7 +38,7 @@ describe('getPackageGreatestVersion', () => {
     expect(version).toEqual('0.1.15')
   })
 
-  it('throws if there is no matching version', async () => {
+  it('returns `undefined` if there is no matching version', async () => {
     nock('https://registry.npmjs.org', {
       reqheaders: {
         Accept: 'application/vnd.npm.install-v1+json',
@@ -46,14 +46,13 @@ describe('getPackageGreatestVersion', () => {
     })
       .get('/@fpjs-incubator/botd-agent')
       .reply(200, mockNpmPackageInfo)
-    await expect(
-      getPackageGreatestVersion('@fpjs-incubator/botd-agent', { start: '0.0', end: '0.1' }, undefined, true),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        name: ErrorName.NpmNotFound,
-        message: 'No version of the NPM package matches ≥0.0 and <0.1',
-      }),
+    const version = await getPackageGreatestVersion(
+      '@fpjs-incubator/botd-agent',
+      { start: '0.0', end: '0.1' },
+      undefined,
+      true,
     )
+    expect(version).toBeUndefined()
   })
 
   it("throws if the package name doesn't exist", async () => {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -62,14 +62,15 @@ const registryUrl = 'https://registry.npmjs.org'
 const packageDownloads = new Map<string, Promise<string>>()
 
 /**
- * Fetches the number of the latest package version from an NPM registry
+ * Fetches the number of the latest package version from an NPM registry.
+ * Returns `undefined` when there is no appropriate version.
  */
 export async function getPackageGreatestVersion(
   name: string,
   versionRange?: VersionRange,
   exclude?: string[],
   onlyStable?: boolean,
-): Promise<string> {
+): Promise<string | undefined> {
   // The dynamic importing is used to reduce the initialization time when the library isn't required
   const { default: got } = await import('got')
   let packageInformation: RegistryPackageShortData
@@ -90,25 +91,7 @@ export async function getPackageGreatestVersion(
     throw error
   }
 
-  const greatestVersion = findGreatestVersion(
-    Object.keys(packageInformation.versions),
-    versionRange,
-    exclude,
-    onlyStable,
-  )
-  if (greatestVersion !== undefined) {
-    return greatestVersion
-  }
-
-  throw createError(
-    ErrorName.NpmNotFound,
-    versionRange?.start || versionRange?.end
-      ? 'No version of the NPM package matches ' +
-          [versionRange?.start && `≥${versionRange.start}`, versionRange?.end && `<${versionRange.end}`]
-            .filter(Boolean)
-            .join(' and ')
-      : 'The NPM package has no versions',
-  )
+  return findGreatestVersion(Object.keys(packageInformation.versions), versionRange, exclude, onlyStable)
 }
 
 /**


### PR DESCRIPTION
- Handle 404 errors that the NPM registry returns for a package metadata (`https://registry.npmjs.org/(name)`) properly. A 404 error for this request means that the package name in the project configuration is wrong, so the application should return a 500 error.
- Write the request data to the console to send it to CloudWatch. Otherwise we won't know what the request URI was in case of an unexpected error.
- Add a timeout to the NPM registry requests