### PR TITLE
feat: add new project for `@fingerprint/gtm-adapter`

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -71,6 +71,7 @@ const botdRouteCommon = {
 } as const
 
 const fingerprintJsProGtmRouteCommon = { type: 'packageMain', globalVariableName: 'FingerprintjsProGTM' } as const
+const fingerprintJsGtmAdapterRouteCommon = { type: 'packageMain', globalVariableName: 'FingerprintGTM' } as const
 
 /**
  * The keys are the first part of the incoming URL. The keys mayn't include slashes.
@@ -140,6 +141,20 @@ export const projects: Record<string, Project> = {
         routes: {
           'iife.js': { ...fingerprintJsProGtmRouteCommon, format: 'iife' },
           'iife.min.js': { ...fingerprintJsProGtmRouteCommon, format: 'iife', minified: true },
+        },
+      },
+    ],
+  },
+
+  // https://github.com/fingerprintjs/gtm-integration
+  'gtm-adapter': {
+    versions: [
+      {
+        npmPackage: '@fingerprint/gtm-adapter',
+        versionRange: { start: '2' },
+        routes: {
+          'iife.js': { ...fingerprintJsGtmAdapterRouteCommon, format: 'iife' },
+          'iife.min.js': { ...fingerprintJsGtmAdapterRouteCommon, format: 'iife', minified: true },
         },
       },
     ],


### PR DESCRIPTION
## Purpose
The Google Tag Manager (GTM) integration is getting a refresh to support v4 and part of that is creating a new package with a new name for the script that wraps the JS agent so it can be called from the GTM sandboxed JS environment. The new package lives at https://www.npmjs.com/package/@fingerprint/gtm-adapter.

This PR adds a new project to serve this script from the CDN, just like the old GTM adapter package `@fingerprintjs/fingerprintjs-pro-gtm`.

For reference, the [GTM template](https://github.com/fingerprintjs/gtm-integration/blob/a81ce98350c9f27b6ca7412d6c1f17d50775328c/template.tpl#L228) loads the wrapper script served from the CDN.

Currently, there is only a prerelease (`2.0.0-test.1`) for `gtm-adapter` on NPM but once we can complete some end-to-end testing with the CDN-served adapter, we are planning to release 2.0.0.

## Test evidence
- `yarn run-lambda --uri /gtm-adapter/v2/iife.min.js --full-response-body` => 404
-- This is expected given that a stable v2 release is not yet available
- `yarn run-lambda --uri /gtm-adapter/v2.0.0-test.1/iife.min.js --full-response-body` => expected JS script
-- We'll use this in the end-to-end testing before the stable release